### PR TITLE
feat: A CBT-6 helper fix

### DIFF
--- a/google/api_core/retry.py
+++ b/google/api_core/retry.py
@@ -288,6 +288,10 @@ class Retry(object):
 
         return retry_wrapped_func
 
+    @property
+    def deadline(self):
+        return self._deadline
+
     def with_deadline(self, deadline):
         """Return a copy of this retry with the given deadline.
 

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -162,6 +162,7 @@ class TestRetry(object):
         assert retry_._multiplier == 2
         assert retry_._deadline == 120
         assert retry_._on_error is None
+        assert retry_.deadline == 120
 
     def test_constructor_options(self):
         _some_function = mock.Mock()


### PR DESCRIPTION
The suggested way of fixing cbt-6 involves propagating the value of a private member of the `Retry` class down to gRPC wrapper. The proposed changes are necessary to avoid the associated linting errors.

_The changes were validated via kokoro tests._